### PR TITLE
Fix to controller/runner.php

### DIFF
--- a/controller/runner.php
+++ b/controller/runner.php
@@ -394,7 +394,8 @@ class SeparatedRunner extends RemoteRunner{
     $runfile_str = $runfile_str.PHP_EOL.$cmd;
 
     // command to remove the compressed file from the cluster
-    $cmd = 'cd '.$this->runtimePath.'; rm '.$data.'.tar.gz &';
+    #$cmd = 'cd '.$this->runtimePath.'; rm '.$data.'.tar.gz &';
+    $cmd = 'rm '.$this->runtimePath.'.tar.gz &';
     $runfile_str = $runfile_str.PHP_EOL.$cmd;
 
     //

--- a/controller/runner.php
+++ b/controller/runner.php
@@ -394,7 +394,6 @@ class SeparatedRunner extends RemoteRunner{
     $runfile_str = $runfile_str.PHP_EOL.$cmd;
 
     // command to remove the compressed file from the cluster
-    #$cmd = 'cd '.$this->runtimePath.'; rm '.$data.'.tar.gz &';
     $cmd = 'rm '.$this->runtimePath.'.tar.gz &';
     $runfile_str = $runfile_str.PHP_EOL.$cmd;
 


### PR DESCRIPTION
Hi,

I am also from the BU group adding a MOC option to ChRIS. In working to get our cluster option added to chrisreloaded, we noticed a small bug in the controller/runner.php file. It appears that the line

    // command to remove the compressed file from the cluster
    $cmd = 'cd '.$this->runtimePath.'; rm '.$data.'.tar.gz &';

doesn't remove the tar file from the cluster as intended since it is trying to 'cd' into the tar file itself. Instead the cleanup will work if the line is changed to:

    // command to remove the compressed file from the cluster
    $cmd = 'rm '.$this->runtimePath.'.tar.gz &';

Hope this helps. Let me know if there is anything else you would like me to include in this pull request.

-Travis Miller